### PR TITLE
Implement a test to ensure linking is done correctly.

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,13 @@
+use libftd2xx_ffi::FT_GetLibraryVersion;
+
+#[test]
+#[cfg(not(windows))]
+fn version() {
+    let mut dw_library_ver = 0;
+
+    let ft_status = unsafe { FT_GetLibraryVersion(&mut dw_library_ver) };
+    assert_eq!(ft_status, 0);
+
+    // version "1.4.8" is represented as 0x010408
+    assert_eq!(dw_library_ver, 0x01_04_08);
+}


### PR DESCRIPTION
On Linux, this project can compile and accidentally add in x86_64 code into an archive that's supposed to be only 32 bit code (version 0.4.0 and earlier). The problem was only detected when trying to link. This test should force linking to occur as it needs to compile and link to run.

On Windows, because things are being dynamically linked, it's more tricky to test. However in practice, it accidentally worked with 32 bit dlls in the correct path.