### PR TITLE
Compile examples as part of CI.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,17 @@
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.arm-unknown-linux-musleabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,17 @@
-[target.'cfg(all(any(target_arch = "arm", target_arch = "armv7"), target_os = "linux"))']
+[target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
-[target.'cfg(all(target_arch = "aarch64", target_os = "linux"))']
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.arm-unknown-linux-musleabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,17 +1,5 @@
-[target.arm-unknown-linux-gnueabihf]
+[target.'cfg(all(any(target_arch = "arm", target_arch = "armv7"), target_os = "linux"))']
 linker = "arm-linux-gnueabihf-gcc"
 
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
-
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-
-[target.arm-unknown-linux-musleabihf]
-linker = "arm-linux-gnueabihf-gcc"
-
-[target.armv7-unknown-linux-musleabihf]
-linker = "arm-linux-gnueabihf-gcc"
-
-[target.aarch64-unknown-linux-musl]
+[target.'cfg(all(target_arch = "aarch64", target_os = "linux"))']
 linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           RUSTFLAGS="-D warnings" cargo build --features=static --target ${{ matrix.target }}
           RUSTFLAGS="-D warnings" cargo build --features=static,bindgen --target ${{ matrix.target }}
+          RUSTFLAGS="-D warnings" cargo build --examples --features=static,bindgen --target ${{ matrix.target }}          
         if: ${{ contains(matrix.target, 'musl') }}
       - name: Build with glibc
         run: |
@@ -54,6 +55,7 @@ jobs:
           RUSTFLAGS="-D warnings" cargo build --features=bindgen  --target ${{ matrix.target }}
           RUSTFLAGS="-D warnings" cargo build --features=static  --target ${{ matrix.target }}
           RUSTFLAGS="-D warnings" cargo build --features=static,bindgen  --target ${{ matrix.target }}
+          RUSTFLAGS="-D warnings" cargo build --examples --features=static,bindgen  --target ${{ matrix.target }}          
         if: ${{ contains(matrix.target, 'gnu') }}
       - run: cargo doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,28 @@ jobs:
         run: sudo apt install libc6-dev-i386
         if: ${{ contains(matrix.target, 'i686') }}
       - name: Install libc6-dev-armhf-cross
-        run: sudo apt install libc6-dev-armhf-cross
+        run: sudo apt install libc6-dev-armhf-cross gcc-8-arm-linux-gnueabihf gcc-arm-linux-gnueabihf
         if: ${{ contains(matrix.target, 'arm') }}
       - name: Install libc6-dev-arm64-cross
-        run: sudo apt install libc6-dev-arm64-cross
+        run: sudo apt install libc6-dev-arm64-cross gcc-8-aarch64-linux-gnu gcc-aarch64-linux-gnu
         if: ${{ contains(matrix.target, 'aarch64') }}
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: ${{ matrix.target }}
-      - run: RUSTFLAGS="-D warnings" cargo build --target ${{ matrix.target }}
-      - run: RUSTFLAGS="-D warnings" cargo build --features=bindgen  --target ${{ matrix.target }}
+      - name: Build with musl
+        run: |
+          RUSTFLAGS="-D warnings" cargo build --features=static --target ${{ matrix.target }}
+          RUSTFLAGS="-D warnings" cargo build --features=static,bindgen --target ${{ matrix.target }}
+        if: ${{ contains(matrix.target, 'musl') }}
+      - name: Build with glibc
+        run: |
+          RUSTFLAGS="-D warnings" cargo build --target ${{ matrix.target }}
+          RUSTFLAGS="-D warnings" cargo build --features=bindgen  --target ${{ matrix.target }}
+          RUSTFLAGS="-D warnings" cargo build --features=static  --target ${{ matrix.target }}
+          RUSTFLAGS="-D warnings" cargo build --features=static,bindgen  --target ${{ matrix.target }}
+        if: ${{ contains(matrix.target, 'gnu') }}
       - run: cargo doc
 
   windows_build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ exclude = [
     "vendor/linux/**/libusb",
 ]
 
+[[bin]]
+name = "example_version"
+path = "examples/version.rs"
+
+[[bin]]
+name = "example_num_devices"
+path = "examples/num_devices.rs"
+
 [dependencies]
 cfg-if = "^1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,6 @@ exclude = [
     "vendor/linux/**/libusb",
 ]
 
-[[bin]]
-name = "example_version"
-path = "examples/version.rs"
-
-[[bin]]
-name = "example_num_devices"
-path = "examples/num_devices.rs"
-
 [dependencies]
 cfg-if = "^1.0.0"
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ symbol errors if using this crate as a c/c++ dependency.
 
 ### Tested Targets
 
+* `aarch64-unknown-linux-gnu` (dynamic + static)
+* `aarch64-unknown-linux-musl` (static)
 * `i686-pc-windows-msvc` (dynamic + static)
 * `i686-unknown-linux-gnu` (dynamic + static)
 * `i686-unknown-linux-musl` (static)
@@ -73,14 +75,10 @@ symbol errors if using this crate as a c/c++ dependency.
 These targets are provided, but they are untested.
 Use at your own risk.
 
-* `aarch64-unknown-linux-gnu` (dynamic + static)
-* `aarch64-unknown-linux-musl` (dynamic + static)
 * `arm-unknown-linux-gnueabihf` (dynamic + static)
-* `arm-unknown-linux-musleabihf` (dynamic + static)
+* `arm-unknown-linux-musleabihf` (static)
 * `armv7-unknown-linux-gnueabihf` (dynamic + static)
-* `armv7-unknown-linux-musleabihf` (dynamic + static)
-* `i686-unknown-linux-musl` (dynamic)
-* `x86_64-unknown-linux-musl` (dynamic)
+* `armv7-unknown-linux-musleabihf` (static)
 
 ## References
 


### PR DESCRIPTION
https://github.com/Grinkers/libftd2xx-ffi-rs/runs/2306259998?check_suite_focus=true
Here's an error trying to dynamically link with musl. I removed it from the list for tested targets. I don't think it can work, as it'll be mixing incompatible libc implementations. I'm not very familiar with musl, but I also think you probably wouldn't want to static link against a glibc library anyway?

I also tested on a physical raspberry pi 3 b+.  One more for #1.