### PR TITLE
Remove legacy_stdio_definitions and user32 (MSVC_PATH)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,10 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }}
+      - run: |
+          cargo build --target ${{ matrix.target }}
+          cargo build --features=static  --target ${{ matrix.target }}
+          cargo build --examples --features=static  --target ${{ matrix.target }}
       - run: cargo doc
 
   linux_test:

--- a/README.md
+++ b/README.md
@@ -42,20 +42,9 @@ the static feature flag.
 [dependencies]
 libftd2xx-ffi = { version = "~0.8.2", features = ["static"] }
 ```
-For GNU/Linux users, no further work is needed.
-Technically this may be preferred, however there may be license
+Static linking may be preferred, however there may be license
 incompatibilities (static linking with GPL code).
 If in doubt, check the FTDI [driver license terms].
-
-On Windows, we rely on MSVC and a manually set "LIBMSVC_PATH" environment
-variable.
-For example a possible 2019 Community installation path may be:
-```
-C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\lib\
-```
-This brings in `legacy_stdio_definitions.lib` and `user32.lib`.
-It seems to play nicely with rust, but you may end up with multiple defined
-symbol errors if using this crate as a c/c++ dependency.
 
 ## Supported Targets
 

--- a/build.rs
+++ b/build.rs
@@ -110,21 +110,7 @@ fn linker_options() {
     println!("cargo:rustc-link-lib=static=ftd2xx");
 
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
-        "windows" => {
-            let libmsvc_path = if let Some(libmsvc_path) = env::var_os("LIBMSVC_PATH") {
-                match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
-                    "x86_64" => format!("{}{}", libmsvc_path.into_string().unwrap(), "\\x64"),
-                    "x86" => format!("{}{}", libmsvc_path.into_string().unwrap(), "\\x64"),
-                    target_arch => panic!("Target architecture not supported: {}", target_arch),
-                }
-            } else {
-                panic!("LIBMSVC_PATH environment variable not found.");
-            };
-
-            println!("cargo:rustc-link-search=native={}", libmsvc_path);
-            println!("cargo:rustc-link-lib=static=legacy_stdio_definitions");
-            println!("cargo:rustc-link-lib=user32");
-        }
+        "windows" => {}
         "linux" => {}
         "macos" => {
             println!("cargo:rustc-link-lib=framework=IOKit");


### PR DESCRIPTION
Looks like this isn't needed in the newer versions supplied by FTDI. This makes it super easy to build and link with rust. Tests now work without further work, so we won't have accidental https://github.com/newAM/libftd2xx-ffi-rs/pull/38.