### PR TITLE
Add links manifest key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added the `links` manifest key.
+
 ## [0.8.4] - 2021-08-14
 ### Added
 - Added pre-generated bindings for `x86_64-apple-darwin`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 repository = "https://github.com/ftdi-rs/libftd2xx-ffi"
 documentation = "https://docs.rs/libftd2xx-ffi"
 license-file = "LICENSE"
+links = "ftd2xx"
 exclude = [
     "vendor/**/*.dll",
     "vendor/**/*.o",


### PR DESCRIPTION
This helps the cargo resolver pick only one version for `libftd2xx`.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key

> Cargo requires that there is at most one package per links value. In other words, it is forbidden to have two packages link to the same native library. This helps prevent duplicate symbols between crates.