### PR TITLE
Chore: Bump macos CI worker to be macos-latest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
   macos_build:
     name: Mac Build
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       RUSTFLAGS: "-D warnings"
       RUSTDOCFLAGS: "-D warnings"
@@ -138,7 +138,7 @@ jobs:
 
   macos_test:
     name: Mac Unit Tests
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
macos-13 runners have been deprecated. See https://github.com/actions/runner-images/issues/13046

in case CI doesn't fully run on PR, here's a pass:
https://github.com/Grinkers/libftd2xx-ffi/actions/runs/20258317529
