### PR TITLE
Panic when trying to compile using windows-gnu with the `static` feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -131,15 +131,27 @@ fn linker_options() {
 
 #[cfg(feature = "static")]
 fn linker_options() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+
+    if target_os == "windows" && target_env == "gnu" {
+        panic!(
+            r#"
+libftd2xx-ffi static linking is not supported when using the windows-gnu target.
+The static library (ftd2xx.lib) is MSVC-compiled and ABI-incompatible with the GNU toolchain.
+Use windows-msvc or disable `static` feature."#
+        );
+    }
+
     println!("cargo:rustc-link-lib=static=ftd2xx");
 
-    match env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
+    match target_os.as_str() {
         "windows" | "linux" => {}
         "macos" => {
             println!("cargo:rustc-link-lib=framework=IOKit");
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
         }
-        target_os => panic!("Target OS not supported: {target_os}"),
+        _ => panic!("Target OS not supported: {target_os}"),
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -137,9 +137,9 @@ fn linker_options() {
     assert!(
         !(target_os == "windows" && target_env == "gnu"),
         r"
-    libftd2xx-ffi static linking is not supported when using the windows-gnu target.
-    The static library (ftd2xx.lib) is MSVC-compiled and ABI-incompatible with the GNU toolchain.
-    Use windows-msvc or disable `static` feature."
+libftd2xx-ffi static linking is not supported when using the windows-gnu target.
+The static library (ftd2xx.lib) is MSVC-compiled and ABI-incompatible with the GNU toolchain.
+Use windows-msvc or disable `static` feature."
     );
 
     println!("cargo:rustc-link-lib=static=ftd2xx");

--- a/build.rs
+++ b/build.rs
@@ -134,14 +134,13 @@ fn linker_options() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
-    if target_os == "windows" && target_env == "gnu" {
-        panic!(
-            r#"
-libftd2xx-ffi static linking is not supported when using the windows-gnu target.
-The static library (ftd2xx.lib) is MSVC-compiled and ABI-incompatible with the GNU toolchain.
-Use windows-msvc or disable `static` feature."#
-        );
-    }
+    assert!(
+        !(target_os == "windows" && target_env == "gnu"),
+        r"
+    libftd2xx-ffi static linking is not supported when using the windows-gnu target.
+    The static library (ftd2xx.lib) is MSVC-compiled and ABI-incompatible with the GNU toolchain.
+    Use windows-msvc or disable `static` feature."
+    );
 
     println!("cargo:rustc-link-lib=static=ftd2xx");
 


### PR DESCRIPTION
I created a test binary `playground` with the contents from https://github.com/ftdi-rs/libftd2xx-ffi/blob/main/examples/num_devices.rs

Using this crate as a dependency with `features = ["static"]` and `cargo build --target x86_64-pc-windows-gnu`, it compiles successfully. Interestingly, it silently proceeds to use dynamic linking. I think with different linkers/versions I've had ABI incompatibilities and UB. 

On my current test windows machine, I have FTD2XX.dll in system32. On a target windows machine, I do not and this fails with a dll error. I don't recall how I managed to have ABI incompatibilities in the past, but I think this should be a build failure as it's either doing the wrong thing or UB.

<img width="345" height="271" alt="20260513_08h42m48s_grim" src="https://github.com/user-attachments/assets/92d56c98-a28f-406f-af63-25a1beec2fdb" />
